### PR TITLE
update fisco relayer code

### DIFF
--- a/appchains/fisco/base.go
+++ b/appchains/fisco/base.go
@@ -2,7 +2,7 @@ package fisco
 
 import (
 	"encoding/json"
-	"fmt"
+	"strconv"
 )
 
 const (
@@ -17,16 +17,18 @@ type CompactBlock struct {
 
 // ChainParams defines the params for the specific chain
 type ChainParams struct {
-	NodeURLs           map[string]string `json:"node_urls"`
-	GroupID            int    `json:"group_id"`
-	ChainID            int64  `json:"chain_id"`
-	IServiceCoreAddr   string `json:"iservice_core_addr"`
-	IServiceMarketAddr string `json:"iservice_market_addr"`
+	NodeURLs           []string `json:"nodes"`
+	GroupID            int      `json:"groupId"`
+	ChainID            int64    `json:"chainId"`
+	IServiceCoreAddr   string   `json:"iserviceCoreAddr"`
+	IServiceMarketAddr string   `json:"iserviceMarketAddr"`
 }
 
 // GetChainID returns the unique chain id from the specified chain params
 func GetChainID(params ChainParams) string {
-	return fmt.Sprintf("%s-%d-%d", ChainType, params.GroupID, params.ChainID)
+	return strconv.FormatInt(params.ChainID, 10)
+
+	//	return fmt.Sprintf("%s-%d-%d", ChainType, params.GroupID, params.ChainID)
 }
 
 // GetChainIDFromBytes returns the unique chain id from the given chain params bytes

--- a/appchains/fisco/chain.go
+++ b/appchains/fisco/chain.go
@@ -19,8 +19,8 @@ import (
 	"relayer/appchains/fisco/iservice"
 	"relayer/common"
 	"relayer/core"
-	"relayer/mysql"
 	"relayer/logging"
+	"relayer/mysql"
 	"relayer/store"
 )
 
@@ -110,6 +110,8 @@ func BuildFISCOChain(
 	if err != nil {
 		return nil, err
 	}
+
+	logging.Logger.Infof("BuildFISCOChain chainInfo is %s", string(chainParams))
 
 	baseCfgBz, err := store.Get(BaseConfigKey())
 	if err != nil {

--- a/cmd/relayer/start.go
+++ b/cmd/relayer/start.go
@@ -46,6 +46,10 @@ func StartCmd() *cobra.Command {
 				return err
 			}
 
+			mysqlConfig := mysql.NewConfig(config)
+			mysql.NewDB(mysqlConfig)
+			defer mysql.Close()
+
 			appChainFactory := appchains.NewAppChainFactory(store)
 			hubChain := hub.BuildIritaHubChain(hub.NewConfig(config))
 
@@ -89,9 +93,6 @@ func StartCmd() *cobra.Command {
 					}
 				}
 			}
-			mysqlConfig := mysql.NewConfig(config)
-			mysql.NewDB(mysqlConfig)
-			defer mysql.Close()
 
 			chainManager := server.NewChainManager(relayerInstance)
 			marketManger := server.NewMarketManager(relayerInstance)

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,6 +1,7 @@
 base:
     app_chain_type: fisco # application chain type
     store_path: .db # store path
+    http_port: 18082
 
 # irita-hub config
 hub:
@@ -35,6 +36,7 @@ fabric:
 
 # fisco config
 fisco:
+    chainId: 1
     monitor_interval: 1 # chain monitoring interval in seconds
     connection_type: channel
     ca_file: /Users/bianjie/BSN/bsnhub-service-relayer/keys/ca.crt
@@ -42,6 +44,10 @@ fisco:
     key_file: /Users/bianjie/BSN/bsnhub-service-relayer/keys/sdk.key
     sm_crypto: true
     priv_key_file: /Users/bianjie/BSN/bsnhub-service-relayer/keys/key.pem
+    nodes:
+        fisco1.bsnbase.com: 192.168.1.72:20200
+        fisco2.bsnbase.com: 192.168.1.72:20201
+
 
 # mysql config
 mysql:
@@ -53,8 +59,8 @@ mysql:
 
 # service config
 service:
-    service_name: fisco-contract-call
-    schemas: wddrdrtg
+    service_name: cross_service_dev
+    schemas: '{"input":{"type":"object"},"output":{"type:"object"}}'
     provider: iaa1fe6gm5kyam6xfs0wngw3d23l9djlyw82xxcjm2
     service_fee: 1000000upoint
     qos: 100

--- a/core/handler.go
+++ b/core/handler.go
@@ -49,5 +49,6 @@ func (r *Relayer) HandleInterchainRequest(chainID string, request InterchainRequ
 		return err
 	}
 
+	r.Logger.Infof("HandleInterchainRequest is End !!!")
 	return nil
 }

--- a/hub/chain.go
+++ b/hub/chain.go
@@ -3,16 +3,16 @@ package hub
 import (
 	"encoding/json"
 	"errors"
-	"strconv"
 	"fmt"
 	servicesdk "github.com/irisnet/service-sdk-go"
 	"github.com/irisnet/service-sdk-go/service"
 	"github.com/irisnet/service-sdk-go/types"
 	"github.com/irisnet/service-sdk-go/types/store"
+	"strconv"
 
 	"relayer/core"
-	"relayer/mysql"
 	"relayer/logging"
+	"relayer/mysql"
 )
 
 // IritaHubChain defines the Irita-Hub chain
@@ -141,15 +141,15 @@ func (ic IritaHubChain) BuildServiceInvocationRequest(
 	if err != nil {
 		return service.InvokeServiceRequest{}, err
 	}
-
 	// TODO: request id, chain id and contract address will be added into the header on-chain when IBC enabled
 	var input ServiceInput
-	inputStr,err:=strconv.Unquote("\""+request.Input+"\"")
+	inputStr, err := strconv.Unquote("\"" + request.Input + "\"")
 	err = json.Unmarshal([]byte(inputStr), &input)
 	if err != nil {
+		logging.Logger.Errorf("Unmarshal error %v", err)
 		return service.InvokeServiceRequest{}, err
 	}
-	if input.Header == nil{
+	if input.Header == nil {
 		return service.InvokeServiceRequest{}, errors.New("input header cannot be empty")
 	}
 	input.AddHeader("RequestID", request.ID)

--- a/mysql/db.go
+++ b/mysql/db.go
@@ -13,17 +13,17 @@ var DB *sql.DB
 
 type table struct {
 	funique_id    int64
-	request_id    string         //请求唯一id
-	from_chainid  string         //起始链ID
-	from_tx       string         //起始链交易ID
-	hub_req_tx    string         //HUB请求交易ID
-	to_chainid    string         //目标链ID
-	to_tx         *string         //目标链交易ID
-	hub_res_tx    string         //HUB响应交易ID
-	from_res_tx   *string         //向起始链响应数据的交易ID
-	tx_status     int         //交易状态
-	tx_time       *time.Time         //交易完成时间
-	tx_createtime time.Time         //交易创建时间
+	request_id    string     //请求唯一id
+	from_chainid  string     //起始链ID
+	from_tx       string     //起始链交易ID
+	hub_req_tx    string     //HUB请求交易ID
+	to_chainid    string     //目标链ID
+	to_tx         *string    //目标链交易ID
+	hub_res_tx    string     //HUB响应交易ID
+	from_res_tx   *string    //向起始链响应数据的交易ID
+	tx_status     int        //交易状态
+	tx_time       *time.Time //交易完成时间
+	tx_createtime time.Time  //交易创建时间
 }
 
 // NewDB create a instance of the mysql db
@@ -101,7 +101,10 @@ func update(field, value, requestID string) error {
 	return nil
 }
 func updateTime(field, requestID string) error {
-	cmd := fmt.Sprintf("UPDATE tb_irita_crosschain_tx SET %s=now() where request_id='%s'", field, requestID)
+
+	timestr := time.Now().Format("2006-01-02 15:04:05")
+
+	cmd := fmt.Sprintf("UPDATE tb_irita_crosschain_tx SET %s='%s' where request_id='%s'", field, timestr, requestID)
 	stmt, err := DB.Prepare(cmd)
 	if err != nil {
 		return err

--- a/mysql/interchain.go
+++ b/mysql/interchain.go
@@ -12,11 +12,11 @@ func OnInterchainRequestReceived(requestID, fromChainID, fromTx string) {
 		return
 	}
 
-	err = update("tx_status", "0", requestID)
-	if err != nil {
-		logging.Logger.Errorf(err.Error())
-		return
-	}
+	//err = update("tx_status", "0", requestID)
+	//if err != nil {
+	//	logging.Logger.Errorf(err.Error())
+	//	return
+	//}
 
 	err = update("from_chainid", fromChainID, requestID)
 	if err != nil {
@@ -81,7 +81,7 @@ func OnInterchainRequestSucceeded(requestID string) {
 	}
 }
 
-func TxErrCollection(requestID, errStr string){
+func TxErrCollection(requestID, errStr string) {
 	err := update("error", errStr, requestID)
 	if err != nil {
 		logging.Logger.Errorf(err.Error())

--- a/server/server.go
+++ b/server/server.go
@@ -8,10 +8,11 @@ import (
 func StartWebServer(
 	chainManager *ChainManager,
 	marketManager *MarketManager,
+	port int,
 ) {
 	srv := NewHTTPService(chainManager, marketManager)
 
-	err := srv.Router.Run(":8082")
+	err := srv.Router.Run(fmt.Sprintf(":%d", port))
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/server/types.go
+++ b/server/types.go
@@ -3,8 +3,8 @@ package server
 import "fmt"
 
 const (
-	CODE_SUCCESS = 0
-	CODE_ERROR   = 1
+	CODE_SUCCESS = 1
+	CODE_ERROR   = 0
 )
 
 // AddChainRequest defines the request to add an app chain
@@ -18,9 +18,10 @@ type AddChainResult struct {
 }
 
 type AddChainAndBindServResult struct {
-	ChainID string `json:"chain_id"`
+	ChainID     string `json:"chain_id"`
 	ServiceName string `json:"service_name"`
 }
+
 // ChainStatus defines the chain status
 type ChainStatus struct {
 	State  bool  `json:"state"`
@@ -28,13 +29,13 @@ type ChainStatus struct {
 }
 
 type AddChainAndBindServRequest struct {
-	ChainParams string `json:"chain_params"`
-	ServParamsPath string  `json:"serv_params_path,omitempty"`
-	ServiceName string `json:"service_name,omitempty"`
-	Schemas     string `json:"schemas,omitempty"`
-	Provider    string `json:"provider,omitempty"`
-	ServiceFee  string `json:"service_fee,omitempty"`
-	QoS         uint64 `json:"qos,omitempty"`
+	ChainParams    string `json:"chain_params"`
+	ServParamsPath string `json:"serv_params_path,omitempty"`
+	ServiceName    string `json:"service_name,omitempty"`
+	Schemas        string `json:"schemas,omitempty"`
+	Provider       string `json:"provider,omitempty"`
+	ServiceFee     string `json:"service_fee,omitempty"`
+	QoS            uint64 `json:"qos,omitempty"`
 }
 
 // AddServiceBindingRequest defines the request to add a service binding
@@ -56,13 +57,14 @@ type UpdateServiceBindingRequest struct {
 // SuccessResponse defines the response on success
 type SuccessResponse struct {
 	Code   int         `json:"code"`
-	Result interface{} `json:"result,omitempty"`
+	Msg    string      `json:"msg"`
+	Result interface{} `json:"data,omitempty"`
 }
 
 // ErrorResponse defines the response on error
 type ErrorResponse struct {
 	Code  int    `json:"code"`
-	Error string `json:"error"`
+	Error string `json:"msg"`
 }
 
 // ValidateChainID validates the given chain ID


### PR DESCRIPTION
1. 增加配置的fisco节点名与节点地址映射配置以及服务名称配置
2. 增加连接fisco的chainId配置，不使用传递的chainId，这两个chainId不是同一个
3. 接口注册参数修改为节点名称列表
4. 修改路由规则，
5. 交易记录存储的chainId修改为注册的chanId的字符串格式
6. AddChain直接使用bodybyte，不再使用绑定的JSON参数
7. 修改Web端口为可配置